### PR TITLE
Changed a link for FPWD publication

### DIFF
--- a/FPWD/2022-12-08/index.html
+++ b/FPWD/2022-12-08/index.html
@@ -584,7 +584,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
         </dt>
         <dd>
           A
-          <a href="https://w3c.github.io/vc-data-integrity/#proofs" class="externalDFN">proof</a>
+          <a href="https://www.w3.org/TR/vc-data-integrity/#proofs" class="externalDFN">proof</a>
           which is a set of attributes that represent a linked data digital
           proof and the parameters required to verify it as defined by
           RDF-N-Quads.

--- a/index.html
+++ b/index.html
@@ -178,7 +178,7 @@
         <dd>
           A
           <a
-            href="https://w3c.github.io/vc-data-integrity/#proofs"
+            href="https://www.w3.org/TR/vc-data-integrity/#proofs"
             class="externalDFN"
             >proof</a
           >


### PR DESCRIPTION
Changed the github.io link into the data integrity spec to the stable, /TR reference. The github.io link created issues with linkchecker (it it a respec document after all) and all stable, normative references should to to the /TR


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-jws-2020/pull/28.html" title="Last updated on Nov 22, 2022, 2:40 PM UTC (386b101)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-jws-2020/28/b9556fa...386b101.html" title="Last updated on Nov 22, 2022, 2:40 PM UTC (386b101)">Diff</a>