### PR TITLE
Fix typos

### DIFF
--- a/index.html
+++ b/index.html
@@ -110,7 +110,7 @@
       <p>
         In general the suites uses the RDF Dataset Normalization Algorithm 
         to transform an input document into its canonical form. 
-        The cannonical representation is then hashed and signed
+        The canonical representation is then hashed and signed
         with a detached signature algorithm.
       </p>
     </section>
@@ -144,7 +144,7 @@
           >
         </dt>
         <dd>
-          An algorithm that takes a message, prefferably in some
+          An algorithm that takes a message, preferably in some
           <a>canonical form</a> and produces a cryptographic output called a
           digest that is often many orders of magnitude smaller than the input
           message. These algorithms are often 1) very fast, 2) non-reversible,
@@ -510,7 +510,7 @@
           </p>
           <p>
             The <code>created</code> property of the proof MUST be an
-            [[ISO_8601]] formated date string.
+            [[ISO_8601]] formatted date string.
           </p>
           <p>
             The <code>proofPurpose</code> property of the proof MUST be a


### PR DESCRIPTION
While reading the standard I noticed a couple of typos.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/fetsorn/vc-jws-2020/pull/30.html" title="Last updated on Dec 29, 2022, 2:11 PM UTC (3531874)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-jws-2020/30/18ca873...fetsorn:3531874.html" title="Last updated on Dec 29, 2022, 2:11 PM UTC (3531874)">Diff</a>